### PR TITLE
Improved tests, reporting and handling

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -186,19 +186,14 @@ task MoveLiveMountNetworkAddress {
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential
         }
-        $lines = ($splat | out-string) -split "`n"
-        Write-Verbose "Remote script:`n$($lines)" -Verbose
         $output = Invoke-VMScript @splat -ErrorAction Stop
-        Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $splat = @{
             ScriptText      = '(Get-NetAdapter| where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Get-NetIPAddress -AddressFamily IPv4).IPAddress'
             ScriptType      = 'PowerShell'
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential
         }
-        Write-Verbose "Remote script:`n$($splat['ScriptText'])" -Verbose
         $output = Invoke-VMScript @splat -ErrorAction Stop
-        Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $new_ip = $output.ScriptOutput -replace "`r`n", ""
         if ( $new_ip -eq $Config.virtualMachines[$i].testIp ) {
             Write-Verbose -Message "$($Config.virtualMachines[$i].mountName) Network Address Status: Assigned to $($new_ip)"

--- a/.build.ps1
+++ b/.build.ps1
@@ -186,7 +186,8 @@ task MoveLiveMountNetworkAddress {
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential
         }
-        Write-Verbose "Remote script:`n$($splat['ScriptText'])" -Verbose
+        $lines = ($splat | out-string) -split "`n"
+        Write-Verbose "Remote script:`n$($lines)" -Verbose
         $output = Invoke-VMScript @splat -ErrorAction Stop
         Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $splat = @{

--- a/.build.ps1
+++ b/.build.ps1
@@ -235,6 +235,21 @@ task Cleanup {
     }
 }
 
+task CleanAll {
+    foreach ($VM in $Config.virtualMachines) {
+        # Check if there is already an existing live mount with the same name
+        if ( $MountTest = (Get-RubrikMount -VMID (Get-RubrikVM -VM "$VM.name").id) | Where-Object {$_.total -ne 0} ) {
+            $MountTest | ForEach-Object {
+                    If ( (Get-RubrikVM -ID $_ -EA 0).name -eq $VM.mountName ) {
+                        Write-Verbose -Message "$($Config.virtualMachines[$i].mountName) removing this live mount" -Verbose        
+                        Remove-RubrikMount $_
+                }
+            }
+        }
+    }
+}
+
+
 task 1_Init `
 GetConfig
 

--- a/.build.ps1
+++ b/.build.ps1
@@ -165,12 +165,12 @@ task MoveLiveMountNetworkAddress {
         # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
         # Try per vm guest credentials first
         if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))" -Verbose
             $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
         }
         # Use global guest credentials
         else {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")" -Verbose
             $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
         }
         # Find the first network interface's MAC 

--- a/.build.ps1
+++ b/.build.ps1
@@ -174,14 +174,18 @@ task MoveLiveMountNetworkAddress {
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential
         }
+        Write-Verbose "Remote script:`n$($splat['ScriptText'])" -Verbose
         $output = Invoke-VMScript @splat -ErrorAction Stop
+        Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $splat = @{
             ScriptText      = '(Get-NetAdapter| where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Get-NetIPAddress -AddressFamily IPv4).IPAddress'
             ScriptType      = 'PowerShell'
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential
         }
+        Write-Verbose "Remote script:`n$($splat['ScriptText'])" -Verbose
         $output = Invoke-VMScript @splat -ErrorAction Stop
+        Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $new_ip = $output.ScriptOutput -replace "`r`n", ""
         if ( $new_ip -eq $Config.virtualMachines[$i].testIp ) {
             Write-Verbose -Message "$($Config.virtualMachines[$i].mountName) Network Address Status: Assigned to $($new_ip)"
@@ -228,8 +232,8 @@ ConnectVMware
 task 3_LiveMount `
 CreateLiveMount,
 ValidateLiveMount,
-ValidateLiveMountTools,
-ValidateRemoteScriptExecution
+ValidateLiveMountTools
+#ValidateRemoteScriptExecution
 
 task 4_LiveMountNetwork `
 MoveLiveMountNetworkAddress,

--- a/.build.ps1
+++ b/.build.ps1
@@ -106,6 +106,18 @@ task ValidateRemoteScriptExecution {
     $i = 0
     foreach ($Mount in $MountArray) {
         $LoopCount = 1
+        # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
+        # Try per vm guest credentials first
+        if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
+            $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
+        }
+        # Use global guest credentials
+        else {
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
+            $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
+        }
+        # Find the first network interface's MAC 
         while ($true) {
             Write-Verbose -Message "Testing script execution on '$($Config.virtualMachines[$i].mountName)', attempt '$LoopCount'..." -Verbose
             $splat = @{
@@ -151,17 +163,17 @@ task MoveLiveMountNetwork {
 task MoveLiveMountNetworkAddress {
     $i = 0
     foreach ($Mount in $MountArray) {
-        # # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
-        # # Try per vm guest credentials first
-        # if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
-        #     Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
-        #     $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
-        # }
-        # # Use global guest credentials
-        # else {
-        #     Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
-        #     $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
-        # }
+        # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
+        # Try per vm guest credentials first
+        if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
+            $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
+        }
+        # Use global guest credentials
+        else {
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
+            $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
+        }
         # Find the first network interface's MAC 
         $TestInterfaceMAC = ((Get-NetworkAdapter -VM $Config.virtualMachines[$i].mountName | Select-Object -first 1).MacAddress).ToLower() -replace ":","-"
         $splat = @{

--- a/.build.ps1
+++ b/.build.ps1
@@ -109,15 +109,14 @@ task ValidateRemoteScriptExecution {
         # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
         # Try per vm guest credentials first
         if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))" -Verbose
             $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
         }
         # Use global guest credentials
         else {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
+            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")" -Verbose
             $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
         }
-        # Find the first network interface's MAC 
         while ($true) {
             Write-Verbose -Message "Testing script execution on '$($Config.virtualMachines[$i].mountName)', attempt '$LoopCount'..." -Verbose
             $splat = @{

--- a/.build.ps1
+++ b/.build.ps1
@@ -178,6 +178,7 @@ task MoveLiveMountNetworkAddress {
         $splat = @{
             ScriptText      = 'Get-NetAdapter | where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Remove-NetRoute -Confirm:$false -ErrorAction SilentlyContinue;`
                                Get-NetAdapter | where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Get-NetIPAddress | Remove-NetIPAddress -confirm:$false;`
+                               Get-NetAdapter | where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Set-NetIPInterface -DHCP Disable;`
                                Get-NetAdapter | where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | `
                                New-NetIPAddress -IPAddress ' + $Config.virtualMachines[$i].testIp + ' -PrefixLength ' + $Config.virtualMachines[$i].testSubnet + `
                                ' -DefaultGateway ' + $Config.virtualMachines[$i].testGateway

--- a/.build.ps1
+++ b/.build.ps1
@@ -191,7 +191,19 @@ task MoveLiveMountNetworkAddress {
         $output = Invoke-VMScript @splat -ErrorAction Stop
         Write-Verbose "Remote script output:`n$($output.ScriptOutput)" -Verbose
         $splat = @{
-            ScriptText      = '(Get-NetAdapter| where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} | Get-NetIPAddress -AddressFamily IPv4).IPAddress'
+            ScriptText      = 'function Elevate-Process  {
+                                param ([string]$exe = $(Throw "Pleave provide the name and path of an executable"),[string]$arguments)
+                                $startinfo = new-object System.Diagnostics.ProcessStartInfo 
+                                $startinfo.FileName = $exe
+                                $startinfo.Arguments = $arguments 
+                                $startinfo.verb = "RunAs" 
+                                $process = [System.Diagnostics.Process]::Start($startinfo)
+                            }
+                            function QueryIP  {
+                               Get-NetAdapter| where {($_.MacAddress).ToLower() -eq "' + $TestInterfaceMAC + '"} 
+                               | Get-NetIPAddress -AddressFamily IPv4).IPAddress
+                            }
+                            Elevate-Process -Exe powershell.exe -Arguments "-noninteractive -command QueryIP > C:\rubrik.txt"'     
             ScriptType      = 'PowerShell'
             VM              = $Config.virtualMachines[$i].mountName
             GuestCredential = $GuestCredential

--- a/.build.ps1
+++ b/.build.ps1
@@ -151,17 +151,17 @@ task MoveLiveMountNetwork {
 task MoveLiveMountNetworkAddress {
     $i = 0
     foreach ($Mount in $MountArray) {
-        # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
-        # Try per vm guest credentials first
-        if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
-            $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
-        }
-        # Use global guest credentials
-        else {
-            Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
-            $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
-        }
+        # # Keeping the guest credential value local since it may only apply to the individual virtual machine in some cases
+        # # Try per vm guest credentials first
+        # if ( Get-Variable -Name "$Config.virtualMachines[$i].guestCred" -ErrorAction SilentlyContinue ) {
+        #     Write-Verbose -Message "Importing Credential file: $($IdentityPath + $($Config.virtualMachines[$i].guestCred))"
+        #     $GuestCredential = Import-Clixml -Path ($IdentityPath + $($Config.virtualMachines[$i].guestCred))
+        # }
+        # # Use global guest credentials
+        # else {
+        #     Write-Verbose -Message "Importing Credential file: $($IdentityPath + "guestCred.XML")"
+        #     $GuestCredential = Import-Clixml -Path ($IdentityPath + "guestCred.XML")
+        # }
         # Find the first network interface's MAC 
         $TestInterfaceMAC = ((Get-NetworkAdapter -VM $Config.virtualMachines[$i].mountName | Select-Object -first 1).MacAddress).ToLower() -replace ":","-"
         $splat = @{
@@ -232,8 +232,8 @@ ConnectVMware
 task 3_LiveMount `
 CreateLiveMount,
 ValidateLiveMount,
-ValidateLiveMountTools
-#ValidateRemoteScriptExecution
+ValidateLiveMountTools,
+ValidateRemoteScriptExecution
 
 task 4_LiveMountNetwork `
 MoveLiveMountNetworkAddress,


### PR DESCRIPTION
# Description

Default test tasks for open ports, running services, and available URLs  have been added. The details on ports, services, and URLs have to be defined in the config json file (see examples).
All tests are wrapped in a "try ... catch" construct, to avoid a single failing test stop the complete test run.
Three new tasks have been added: "prep", "test", and "clean". The "prep" task creates all the live mounts and modifies their network settings. The "test" task runs only the tests ("prep" doesn't run any tests) and can be run multiple times without the need to recreate live mounts. Once testing has finshed, the "clean" task removes the live mounts.
All tests are summarized as small table at the end of each run. Furthermore,  the test results are written to a json file ("./TestSummary.json"). This file can be used for additional reporting, e. g. it can be converted to an HTML file and then attached to an email.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

* Additional tests (URLs)
* Make tests more granular (generic tests for ports, services, and URLs)
* New task to improve handling and debugging (prep, test, and clean)
* Basic reporting (summary at the end + ./TestSummary.json)

## How Has This Been Tested?

* PowerShell core on Windows and Mac OS
* PowerShell on Windows

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)